### PR TITLE
Optimize function 'times' to O(1)

### DIFF
--- a/pad.go
+++ b/pad.go
@@ -5,11 +5,13 @@ Package pad provides left-padding functionality
 */
 package pad
 
-func times(str string, n int) (out string) {
-	for i := 0; i < n; i++ {
-		out += str
+import "strings"
+
+func times(str string, n int) string {
+	if n <= 0 {
+		return ""
 	}
-	return
+	return strings.Repeat(str, n)
 }
 
 // Left left-pads the string with pad up to len runes


### PR DESCRIPTION
By replacing loop with Go's built-in [strings package](https://golang.org/pkg/strings/#Repeat), this will pad string faster especially with large number (>1000)